### PR TITLE
Ensure the read region is completely flushed

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -540,13 +540,14 @@ acquire_stop(struct AcquireRuntime* self_)
         // Flush the monitor's read region if it hasn't already been released.
         // This takes at most 2 iterations.
         {
-            size_t nbytes = 0;
+            size_t nbytes;
             do {
                 struct slice slice =
                   channel_read_map(&video->sink.in, &video->monitor.reader);
+                nbytes = slice_size_bytes(&slice);
                 channel_read_unmap(&video->sink.in,
                                    &video->monitor.reader,
-                                   slice_size_bytes(&slice));
+                                   nbytes);
                 TRACE("[stream: %d] Monitor flushed %llu bytes", i, nbytes);
             } while (nbytes);
         }


### PR DESCRIPTION
Without this, we go through this block exactly once, potentially leaving some data mapped.