### PR TITLE
Misc tests and CI fixes

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,10 +1,7 @@
-name: Tests
+name: Test and merge
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -15,6 +12,7 @@ jobs:
   test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -32,6 +30,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          ref: "refs/pull/${{ github.event.number }}/merge"
 
       - name: Install Cmake 3.23
         if: ${{ matrix.platform == 'ubuntu-latest' }}
@@ -50,4 +49,30 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} -L runtime --output-on-failure
+        run: ctest -C ${{env.BUILD_TYPE}} -L anyplatform --output-on-failure
+
+  auto-merge:
+    name: "Auto-merge Dependabot PRs"
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: "Get Dependabot metadata"
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: ${{ github.token }}
+
+      - name: "Approve the PR"
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}
+
+      # Don't auto-merge major version updates
+      - name: "Auto-merge the PR"
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -50,4 +50,4 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} -L runtime --output-on-failure
+        run: ctest -C ${{env.BUILD_TYPE}} -L acquire-video-runtime --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
         )
         target_compile_definitions(${tgt} PUBLIC TEST="${tgt}")
         add_test(NAME test-${tgt} COMMAND ${tgt})
-        set_tests_properties(test-${tgt} PROPERTIES LABELS runtime)
+        set_tests_properties(test-${tgt} PROPERTIES LABELS "anyplatform;runtime")
     endforeach()
 
     #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
         )
         target_compile_definitions(${tgt} PUBLIC TEST="${tgt}")
         add_test(NAME test-${tgt} COMMAND ${tgt})
-        set_tests_properties(test-${tgt} PROPERTIES LABELS "anyplatform;runtime")
+        set_tests_properties(test-${tgt} PROPERTIES LABELS "anyplatform;acquire-video-runtime")
     endforeach()
 
     #


### PR DESCRIPTION
- Fixes an error in the Dependabot automerge job where tests would be run against the main branch rather than the ref branch.
- Applies both `runtime` and `anyplatform` labels to runtime tests
- Runs `runtime` labeled tests in CI. This may or may not be the right choice, depending on where we want responsibility for ensuring passing core-libs and driver-common tests to lie.