### PR TITLE
check for mapped reader

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -3,6 +3,7 @@
 #include "device/hal/camera.h"
 #include "logger.h"
 #include "platform.h"
+#include "runtime/channel.h"
 #include "runtime/video.h"
 #include "runtime/vfslice.h"
 
@@ -96,10 +97,11 @@ acquire_map_read(const struct AcquireRuntime* self_,
            "Invalid parameter: `istream` was out-of-bounds (%d).",
            countof(self->video));
     self = containerof(self_, struct runtime, handle);
+    EXPECT(self->video[istream].monitor.reader.state == ChannelState_Unmapped,
+           "Expected an unmapped reader. See acquire_unmap_read().");
     struct vfslice_mut slice = make_vfslice_mut(channel_read_map(
       &self->video[istream].sink.in, &self->video[istream].monitor.reader));
-    EXPECT(self->video[istream].monitor.reader.status == Channel_Ok,
-           "Expected an unmapped reader. See acquire_unmap_read().");
+    CHECK(self->video[istream].monitor.reader.status == Channel_Ok);
     *beg = slice.beg;
     *end = slice.end;
     return AcquireStatus_Ok;

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -98,6 +98,8 @@ acquire_map_read(const struct AcquireRuntime* self_,
     self = containerof(self_, struct runtime, handle);
     struct vfslice_mut slice = make_vfslice_mut(channel_read_map(
       &self->video[istream].sink.in, &self->video[istream].monitor.reader));
+    EXPECT(self->video[istream].monitor.reader.status == Channel_Ok,
+           "Expected an unmapped reader. See acquire_unmap_read().");
     *beg = slice.beg;
     *end = slice.end;
     return AcquireStatus_Ok;


### PR DESCRIPTION
Fixes an unchecked failure in `acquire_map_read()` caused when a caller fails to call `acquire_unmap_read()` at the right time.

For example:

```c
acquire_map_read(runtime,0,&beg,&end);
// When end>beg
acquire_map_read(runtime,0,beg,end); // Should return AcquireStatus_Error
```

whereas


```c
acquire_map_read(runtime,0,&beg,&end);
// When end>beg
acquire_unmap_read(runtime,0,&beg,&end);
acquire_map_read(runtime,0,beg,end); // Should return AcquireStatus_Ok
```

acquire-project/acquire-driver-common#34 depends on this 