### PR TITLE
Fix: configure sink with frame delay

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -288,7 +288,7 @@ configure_video_stream(struct video_s* const video,
                             device_manager,
                             &pstorage->identifier,
                             &pstorage->settings,
-                            (float)pvideo->frame_average_count) == Device_Ok);
+                            pstorage->write_delay_ms) == Device_Ok);
 
     EXPECT(is_ok, "Failed to configure video stream.");
 

--- a/src/runtime/sink.c
+++ b/src/runtime/sink.c
@@ -121,6 +121,7 @@ video_sink_get(const struct video_sink_s* const self,
                float* const write_delay_ms)
 {
     *identifier = self->identifier;
+    *write_delay_ms = self->write_delay_ms;
 
     if (self->storage) {
         CHECK(storage_get(self->storage, settings) == Device_Ok);


### PR DESCRIPTION
In Acquire's high level configuration, we allow a delay to be set which dictates when the sink thread/channel will unmap/release the memory associated with some number of frames. This needs to be passed through to the `video_sink_s` struct in `configure_video_stream` in order to take effect.

Before this PR, that parameter value was mistakenly coming from the `frame_average_count`. This PR fixes that to use `frame_delay_ms`. This PR also update the sink's frame delay on `acquire_get_configuration`, which was previously being ignored.

This was probably not a significant issue/bug because this feature is likely unused and because the `frame_average_count` is also rarely used, so both values are often just 0 by default and have no effect.

I caught this bug while prototyping some ideas for online video processing.