### PR TITLE
Persistent storage

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -247,23 +247,6 @@ Error:
 }
 
 static enum AcquireStatusCode
-configure_storage(struct video_s* const video,
-                  const struct DeviceManager* const device_manager,
-                  struct aq_properties_storage_s* const pstorage)
-{
-    // Storage
-    EXPECT(storage_validate(
-             device_manager, &pstorage->identifier, &pstorage->settings),
-           "Storage properties failed to validate.");
-    video->sink.identifier = pstorage->identifier;
-    CHECK(Device_Ok ==
-          storage_properties_copy(&video->sink.settings, &pstorage->settings));
-    return AcquireStatus_Ok;
-Error:
-    return AcquireStatus_Error;
-}
-
-static enum AcquireStatusCode
 configure_video_stream(struct video_s* const video,
                        enum DeviceState state,
                        const struct DeviceManager* const device_manager,

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -493,8 +493,7 @@ acquire_start(struct AcquireRuntime* self_)
             continue;
         }
 
-        CHECK(video_sink_start(&video->sink, &self->device_manager) ==
-              Device_Ok);
+        CHECK(video_sink_start(&video->sink) == Device_Ok);
         CHECK(reserve_image_shape(video));
         CHECK(video_filter_start(&video->filter) == Device_Ok);
         CHECK(video_source_start(&video->source) == Device_Ok);

--- a/src/runtime/sink.h
+++ b/src/runtime/sink.h
@@ -42,8 +42,7 @@ extern "C"
 
     void video_sink_destroy(struct video_sink_s* self);
 
-    enum DeviceStatusCode video_sink_start(struct video_sink_s* self,
-                                           struct DeviceManager* dm);
+    enum DeviceStatusCode video_sink_start(struct video_sink_s* self);
 
     /// @brief Query the video sink controller's properties.
     /// @param [in] self A `video_sink_s` context.

--- a/tests/one-video-stream.cpp
+++ b/tests/one-video-stream.cpp
@@ -57,7 +57,7 @@ main()
 
     DEVOK(device_manager_select(dm,
                                 DeviceKind_Camera,
-                                SIZED("simulated.*random.*") - 1,
+                                SIZED("simulated.*empty.*") - 1,
                                 &props.video[0].camera.identifier));
     DEVOK(device_manager_select(dm,
                                 DeviceKind_Storage,
@@ -78,7 +78,6 @@ main()
         .x = 1920,
         .y = 1080,
     };
-    props.video[0].camera.settings.exposure_time_us = 1e4;
     props.video[0].max_frame_count = 10;
 
     OK(acquire_configure(runtime, &props));


### PR DESCRIPTION
- Don't destroy the `Storage` object at the end of acquisition.
- Expect non-null `Storage` pointer on `video_sink_start()`.
- Remove some unused code.
- Update `one-video-stream` test to use simulated: empty.

Depends on https://github.com/acquire-project/acquire-core-libs/pull/42