### PR TITLE
Handle zero bytes available in channel_read_map

### DIFF
--- a/src/runtime/channel.c
+++ b/src/runtime/channel.c
@@ -91,9 +91,9 @@ reader_initialize(struct channel* self, struct channel_reader* reader)
 {
     if (reader->id > 0)
         return 1;
-    self->holds.cycles[reader->id] = self->cycle;
-    self->holds.pos[reader->id] = 0;
     reader->id = ++self->holds.n;
+    self->holds.cycles[reader->id - 1] = self->cycle;
+    self->holds.pos[reader->id - 1] = 0;
     if (self->holds.n >= MAX_READERS)
         return 0;
     return 1;

--- a/src/runtime/channel.c
+++ b/src/runtime/channel.c
@@ -191,6 +191,9 @@ channel_read_map(struct channel* self, struct channel_reader* reader)
         reader->cycle = *cycle + 1;
     }
 
+    if (!nbytes) // nothing available on the channel
+        goto Error;
+
     reader->state = ChannelState_Mapped;
 
 Finalize:

--- a/src/runtime/channel.h
+++ b/src/runtime/channel.h
@@ -17,14 +17,34 @@ extern "C"
     {
         struct lock lock;
         struct condition_variable notify_space_available;
+
+        /// Pointer to the start of the channel's buffer.
         uint8_t* data;
-        size_t capacity, head, high, cycle, mapped;
+
+        /// Maximum number of bytes this channel can hold.
+        size_t capacity;
+
+        /// Position in the channel where the next write operation will occur.
+        size_t head;
+
+        /// Highest position in the channel that has been written to in the current cycle.
+        size_t high;
+
+        /// Number of times the buffer has been filled and wrapped around to the start.
+        size_t cycle;
+
+        /// Pointer to end position of reserved region before committing a write.
+        size_t mapped;
+
+        /// Whether or not the channel is accepting writes.
         unsigned char is_accepting_writes;
+
+        /// Current positions and cycles of readers on this channel.
         struct
         {
             size_t pos[8];
             size_t cycles[8];
-            unsigned n;
+            unsigned n; /// Number of readers currently reading from the channel.
         } holds;
     };
 

--- a/src/runtime/channel.h
+++ b/src/runtime/channel.h
@@ -33,7 +33,7 @@ extern "C"
         /// Number of times the buffer has been filled and wrapped around to the start.
         size_t cycle;
 
-        /// Pointer to end position of reserved region before committing a write.
+        /// Pointer to the end position of the reserved region of a mapped write.
         size_t mapped;
 
         /// Whether or not the channel is accepting writes.

--- a/tests/no-abort-on-dropped-frames.cpp
+++ b/tests/no-abort-on-dropped-frames.cpp
@@ -117,7 +117,7 @@ acquire(AcquireRuntime* runtime, const AcquireProperties& props)
 
     // even though we expect to have dropped some frames, the runtime must not
     // have aborted!
-    ASSERT_NEQ(
+    ASSERT_EQ(
       unsigned long long, "%llu", nframes, props.video[0].max_frame_count);
     CHECK(introspective_logger.frames_were_dropped());
 }

--- a/tests/no-abort-on-dropped-frames.cpp
+++ b/tests/no-abort-on-dropped-frames.cpp
@@ -115,13 +115,14 @@ acquire(AcquireRuntime* runtime, const AcquireProperties& props)
         OK(acquire_unmap_read(runtime, 0, (uint8_t*)end - (uint8_t*)beg));
     }
 
-    OK(acquire_stop(runtime));
-
     do {
         OK(acquire_map_read(runtime, 0, &beg, &end));
         for (cur = beg; cur < end; cur = next(cur))
             ++nframes;
+        OK(acquire_unmap_read(runtime, 0, (uint8_t*)end - (uint8_t*)beg));
     } while (beg != end);
+
+    OK(acquire_stop(runtime));
 
     // even though we expect to have dropped some frames, the runtime must not
     // have aborted!

--- a/tests/no-abort-on-dropped-frames.cpp
+++ b/tests/no-abort-on-dropped-frames.cpp
@@ -109,7 +109,7 @@ acquire(AcquireRuntime* runtime, const AcquireProperties& props)
         OK(acquire_map_read(runtime, 0, &beg, &end));
         for (cur = beg; cur < end; cur = next(cur))
             ++nframes;
-        clock_sleep_ms(0, 100.0);
+        clock_sleep_ms(nullptr, 10.0);
         OK(acquire_unmap_read(runtime, 0, (uint8_t*)end - (uint8_t*)beg));
     }
 


### PR DESCRIPTION
- Fixes a bug in `reader_initialize()`.
- Update cycle and position for the channel hold, but do not set the channel state to `Mapped`, if no bytes are available to read.