### PR TITLE
Minor storage updates

### DIFF
--- a/src/runtime/sink.c
+++ b/src/runtime/sink.c
@@ -180,8 +180,6 @@ video_sink_configure(struct video_sink_s* self,
                      struct StorageProperties* settings,
                      float write_delay_ms)
 {
-    EXPECT(storage_validate(device_manager, identifier, settings),
-           "Storage properties failed to validate.");
     self->write_delay_ms = write_delay_ms;
     self->identifier = *identifier;
     if (self->storage && !is_equal(&self->identifier, identifier)) {

--- a/src/runtime/sink.c
+++ b/src/runtime/sink.c
@@ -136,14 +136,7 @@ video_sink_get(const struct video_sink_s* const self,
     *identifier = self->identifier;
     *write_delay_ms = self->write_delay_ms;
 
-    if (self->storage) {
-        CHECK(storage_get(self->storage, settings) == Device_Ok);
-    } else {
-        CHECK(storage_properties_copy(settings, &self->settings));
-    }
-    return Device_Ok;
-Error:
-    return Device_Err;
+    return self->storage ? storage_get(self->storage, settings) : Device_Ok;
 }
 
 void

--- a/src/runtime/sink.c
+++ b/src/runtime/sink.c
@@ -38,9 +38,6 @@ video_sink_init(struct video_sink_s* self,
     memset(self, 0, sizeof(*self));
     self->stream_id = stream_id;
     self->sig_stop_source = sig_stop_source;
-    EXPECT(storage_properties_init(
-             &self->settings, 0, 0, 0, 0, 0, (struct PixelScale){ 0 }),
-           "Failed to initialize storage properties");
 
     LOG("Video[%2d]: Allocating %llu bytes for the queue.",
         stream_id,
@@ -147,7 +144,6 @@ video_sink_destroy(struct video_sink_s* self)
         storage_close(self->storage);
     }
     channel_release(&self->in);
-    storage_properties_destroy(&self->settings);
 }
 
 size_t

--- a/src/runtime/sink.h
+++ b/src/runtime/sink.h
@@ -30,7 +30,6 @@ extern "C"
         struct channel in;
         struct thread thread;
         struct DeviceIdentifier identifier;
-        struct StorageProperties settings;
         struct channel_reader reader;
     };
 


### PR DESCRIPTION
Makes the video sink somewhat more like the video source. In particular:

- Don't do a separate validation step for the Storage device on `video_sink_configure()`.
- Remove the extraneous `video_sink_s.settings` member.